### PR TITLE
poe interface power-limit doesn't work - bug fix

### DIFF
--- a/sai-poe-implementation/src/poe_v3.c
+++ b/sai-poe-implementation/src/poe_v3.c
@@ -1115,6 +1115,7 @@ POE_OP_RESULT_ENT poeDevGetPowerConsumption (
     result = poeV3SendReceiveMsg(POE_V3_MSG_LEVEL_SYSTEM_CNS, POE_V3_MSG_DIR_GET_CNS, POE_V3_SYS_MSG_POWER_CONSUMPTION_CNS, sizeof(powerConsumptionParams), (UINT_8*)&powerConsumptionParams);
     if(result == POE_OP_OK_E) {
         *powerConsumptionMwPtr = (swap32(powerConsumptionParams.powerConsumptionSwap)) + 0.5;
+        LOG_PRINT("total power consumption %d", *powerConsumptionMwPtr);
     }
     else {
         LOG_ERROR("failed to get data");
@@ -1578,6 +1579,8 @@ POE_OP_RESULT_ENT poePortSetPowerLimit (
         LOG_ERROR("failed to set data");
     }
 
+    LOG_PRINT("power limit %d, port %d", powerLimit, frontPanelIndex);
+
     rwlock_excl_release(&poe_v3_lock);
 
     return result;
@@ -1639,6 +1642,8 @@ POE_OP_RESULT_ENT poePortSetPowerPriority (
 
     portPriorityParams.logicPortNum = (UINT_8)frontPanelIndex;
     portPriorityParams.portPriority = powerPriority;
+
+    LOG_PRINT("power priority %d, port %d", powerPriority, frontPanelIndex);
 
     result = poeV3SendReceiveMsg(POE_V3_MSG_LEVEL_PORT_CNS, POE_V3_MSG_DIR_SET_CNS, POE_V3_PORT_MSG_PORT_PRIORITY_CNS, sizeof(portPriorityParams), (uint8_t*)&portPriorityParams);
 

--- a/sai-poe-implementation/src/sai/sai_poe.c
+++ b/sai-poe-implementation/src/sai/sai_poe.c
@@ -756,9 +756,11 @@ static sai_status_t set_poe_port_attribute(_In_ sai_object_id_t poe_port_id, _In
         result = poePortSetAdminEnable(port_id, attr->value.booldata);
         break;
     case SAI_POE_PORT_ATTR_POWER_LIMIT:
-        result = poeDevSetPowerLimitMode(port_id, attr->value.u32);
+        LOG_PRINT("port %d, set power limit %d", port_id, attr->value.u32);
+        result = poePortSetPowerLimit(port_id, attr->value.u32);
         break;
     case SAI_POE_PORT_ATTR_POWER_PRIORITY:
+        LOG_PRINT("port %d, set power priority %d", port_id, attr->value.s32);
         result = poePortSetPowerPriority(port_id, attr->value.s32);
         break;
     default:


### PR DESCRIPTION
Change-Id: Iede38aa1187e1f38cd8dae0246e13ebb3a77a299
Fix: set power limit mode was called instead of set port power limit 
https://github.com/Marvell-switching/sai-poe/issues/10 